### PR TITLE
fix: draggability of title bar

### DIFF
--- a/packages/desktop/src/app/components/App.svelte
+++ b/packages/desktop/src/app/components/App.svelte
@@ -40,7 +40,6 @@
   }
 
   main {
-    margin-top: 20px;
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/packages/desktop/src/app/components/TodoContainer.svelte
+++ b/packages/desktop/src/app/components/TodoContainer.svelte
@@ -278,6 +278,7 @@
 
 <style>
   form {
+    margin-top: 20px;
     position: relative;
     text-align: center;
     width: 100%;

--- a/packages/mobile/src/components/TodoContainer.svelte
+++ b/packages/mobile/src/components/TodoContainer.svelte
@@ -282,6 +282,7 @@
 
 <style>
   form {
+    margin-top: 20px;
     position: relative;
     text-align: center;
     width: 100%;


### PR DESCRIPTION
This patch resolves a bug where the application window cannot be dragged when grabbed near the top half of the title bar.

I didn't thoroughly test this change (I'm not setup to build for iOS/macOS), but it seems to do the trick for the Electron instance (`yarn workspace @today/desktop start`).

I came across this app in the App Store for macOS and found it useful, thanks!